### PR TITLE
Fully implement and test async SSTable creation

### DIFF
--- a/db/lsm/create_sstable_test.go
+++ b/db/lsm/create_sstable_test.go
@@ -1,0 +1,281 @@
+package lsm
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/navijation/njsimple/util"
+	testing_util "github.com/navijation/njsimple/util/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLSMDB_CreateSSTable(t *testing.T) {
+	t.Parallel()
+
+	dir, cleanup := testing_util.MkdirTemp(t, "TestLSMDB_CreateSSTable")
+	cleanup()
+	defer cleanup()
+
+	const numTestKeyValues = uint64(100)
+
+	db, err := Open(OpenArgs{
+		Path:           dir,
+		Create:         true,
+		IndexChunkSize: util.Some(uint64(1000)),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, db.Start())
+
+	require.Len(t, db.writeAheadLogs, 1)
+
+	for i := range numTestKeyValues {
+		require.NoError(t, db.Upsert(
+			[]byte(fmt.Sprintf("key %03d", i)), []byte(fmt.Sprintf("value %d", i))),
+		)
+	}
+
+	writeAheadLog := db.writeAheadLogs[0]
+	assert.Equal(t, numTestKeyValues, writeAheadLog.NumEntries())
+
+	require.NoError(t, db.CreateSSTable())
+
+	t.Run("assert writeahead log has entry", func(t *testing.T) {
+		assert.Equal(t, numTestKeyValues+1, writeAheadLog.NumEntries())
+
+		cursor := writeAheadLog.NewCursor(false)
+		for _ = range numTestKeyValues {
+			_, exists, err := cursor.NextEntry()
+			_ = assert.NoError(t, err) && assert.True(t, exists)
+		}
+
+		lastEntry, exists, err := cursor.NextEntry()
+		if assert.NoError(t, err) && assert.True(t, exists) {
+			entry, err := parseJournalEntry(&lastEntry)
+			if assert.NoError(t, err) && assert.IsType(t, CreateSSTableEntry{}, entry) {
+				entry := entry.(CreateSSTableEntry)
+				assert.EqualValues(t, 1, entry.SSTableNumber)
+				assert.EqualValues(t, 2, entry.WriteAheadLogNumber)
+				assert.Nil(t, entry.index)
+			}
+		}
+	})
+
+	time.Sleep(500 * time.Millisecond)
+
+	t.Run("Fields after file is committed", func(t *testing.T) {
+		if assert.Len(t, db.writeAheadLogs, 1) {
+			assert.Zero(t, db.writeAheadLogs[0].NumEntries())
+		}
+		if assert.Len(t, db.inMemoryIndexes, 1) {
+			assert.Empty(t, db.inMemoryIndexes[0].KeyValues)
+		}
+		if assert.Len(t, db.sstables, 1) {
+			assert.Equal(t, numTestKeyValues, db.sstables[0].NumEntries())
+		}
+		assert.NoError(t, db.stateErr)
+	})
+
+	t.Run("Lookup after file is committed", func(t *testing.T) {
+		for i := range numTestKeyValues {
+			entry, exists, err := db.Lookup([]byte(fmt.Sprintf("key %03d", i)))
+			_ = assert.NoError(t, err) && assert.True(t, exists) &&
+				assert.Equal(t, []byte(fmt.Sprintf("value %d", i)), entry.Value) &&
+				assert.False(t, entry.IsDeleted)
+		}
+	})
+
+	require.NoError(t, db.Close())
+
+	sameDB, err := Open(OpenArgs{
+		Path:           dir,
+		Create:         false,
+		IndexChunkSize: util.Some(uint64(1000)),
+	})
+	require.NoError(t, err)
+
+	t.Run("Fields after DB is reopened", func(t *testing.T) {
+		if assert.Len(t, sameDB.writeAheadLogs, 1) {
+			assert.Zero(t, sameDB.writeAheadLogs[0].NumEntries())
+		}
+		if assert.Len(t, sameDB.inMemoryIndexes, 1) {
+			assert.Empty(t, sameDB.inMemoryIndexes[0].KeyValues)
+		}
+		if assert.Len(t, sameDB.sstables, 1) {
+			assert.Equal(t, numTestKeyValues, sameDB.sstables[0].NumEntries())
+		}
+		assert.EqualValues(t, 2, sameDB.nextSSTableNumber)
+		assert.EqualValues(t, 3, sameDB.nextWriteAheadLogNumber)
+		assert.NoError(t, sameDB.stateErr)
+	})
+
+	t.Run("Lookup reopened DB", func(t *testing.T) {
+		for i := range numTestKeyValues {
+			entry, exists, err := sameDB.Lookup([]byte(fmt.Sprintf("key %03d", i)))
+			_ = assert.NoError(t, err) && assert.True(t, exists) &&
+				assert.Equal(t, []byte(fmt.Sprintf("value %d", i)), entry.Value) &&
+				assert.False(t, entry.IsDeleted)
+		}
+	})
+}
+
+func TestLSMDB_ConcurrentSSTableAndCUD(t *testing.T) {
+	t.Parallel()
+
+	dir, cleanup := testing_util.MkdirTemp(t, "TestLSMDB_ConcurrentSSTableAndCUD")
+	cleanup()
+	defer cleanup()
+
+	const numTestKeyValues = uint64(100)
+
+	db, err := Open(OpenArgs{
+		Path:           dir,
+		Create:         true,
+		IndexChunkSize: util.Some(uint64(1000)),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, db.Start())
+
+	var (
+		writeCounter1 atomic.Int64
+		writeCounter2 atomic.Int64
+	)
+
+	go func() {
+		for i := range numTestKeyValues {
+			require.NoError(t, db.Upsert(
+				[]byte(fmt.Sprintf("keyX %03d", i)), []byte(fmt.Sprintf("value %d", i))),
+			)
+			writeCounter1.Add(1)
+		}
+	}()
+
+	go func() {
+		for i := range numTestKeyValues {
+			require.NoError(t, db.Upsert(
+				[]byte(fmt.Sprintf("keyY %03d", i)), []byte(fmt.Sprintf("value %d", i))),
+			)
+			writeCounter2.Add(1)
+		}
+		for i := range numTestKeyValues {
+			require.NoError(t, db.Delete([]byte(fmt.Sprintf("keyY %03d", i))))
+			writeCounter2.Add(1)
+		}
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	// ensure at least a quarter of both data has been written by both goroutines
+	for writeCounter1.Load() < int64(numTestKeyValues)/4 ||
+		writeCounter2.Load() < int64(numTestKeyValues)/4 {
+
+		if time.Now().After(deadline) {
+			require.Failf(t, "Deadline exceeded", "Deadline exceeded on counters %d and %d",
+				writeCounter1.Load(), writeCounter2.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	require.NoError(t, db.CreateSSTable())
+
+	deadline = time.Now().Add(7 * time.Second)
+	for (writeCounter1.Load() + writeCounter2.Load()) < 3*int64(numTestKeyValues) {
+		if time.Now().After(deadline) {
+			require.Failf(t, "Deadline exceeded", "Deadline exceeded on counters %d and %d",
+				writeCounter1.Load(), writeCounter2.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	require.NoError(t, db.CreateSSTable())
+
+	time.Sleep(500 * time.Millisecond)
+
+	t.Run("Fields after file is committed", func(t *testing.T) {
+		assert.EqualValues(t, 3, db.nextSSTableNumber)
+		assert.EqualValues(t, 4, db.nextWriteAheadLogNumber)
+		if assert.Len(t, db.inMemoryIndexes, 1) {
+			assert.Empty(t, db.inMemoryIndexes[0].KeyValues)
+		}
+		assert.Len(t, db.writeAheadLogs, 1)
+		assert.Len(t, db.sstables, 2)
+
+		assert.True(t, db.isRunning.Load())
+		assert.NoError(t, db.stateErr)
+	})
+
+	t.Run("Key lookup after file is committed", func(t *testing.T) {
+		for i := range numTestKeyValues {
+			value := []byte(fmt.Sprintf("value %d", i))
+
+			keyX := []byte(fmt.Sprintf("keyX %03d", i))
+			entry, ok, err := db.Lookup(keyX)
+			require.NoError(t, err, string(keyX))
+			require.True(t, ok, string(keyX))
+			require.Equal(t, KeyValuePair{
+				Key:   keyX,
+				Value: value,
+			}, entry, string(keyX))
+
+			keyY := []byte(fmt.Sprintf("keyY %03d", i))
+			entry, ok, err = db.Lookup(
+				[]byte(fmt.Sprintf("keyY %03d", i)),
+			)
+			require.NoError(t, err, string(keyY))
+			require.True(t, ok, string(keyY))
+			require.Equal(t, KeyValuePair{
+				Key:       keyY,
+				IsDeleted: true,
+			}, entry, string(keyY))
+		}
+	})
+	db.Close()
+
+	sameDB, err := Open(OpenArgs{
+		Path:           dir,
+		IndexChunkSize: util.Some(uint64(1000)),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, sameDB.Start())
+
+	t.Run("Fields after file is committed", func(t *testing.T) {
+		assert.EqualValues(t, 3, sameDB.nextSSTableNumber)
+		assert.EqualValues(t, 4, sameDB.nextWriteAheadLogNumber)
+		if assert.Len(t, sameDB.inMemoryIndexes, 1) {
+			assert.Empty(t, sameDB.inMemoryIndexes[0].KeyValues)
+		}
+		assert.Len(t, sameDB.writeAheadLogs, 1)
+		assert.Len(t, sameDB.sstables, 2)
+
+		assert.True(t, sameDB.isRunning.Load())
+		assert.NoError(t, sameDB.stateErr)
+	})
+
+	t.Run("Key lookup after file is committed", func(t *testing.T) {
+		for i := range numTestKeyValues {
+			value := []byte(fmt.Sprintf("value %d", i))
+
+			keyX := []byte(fmt.Sprintf("keyX %03d", i))
+			entry, ok, err := sameDB.Lookup(keyX)
+			require.NoError(t, err, string(keyX))
+			require.True(t, ok, string(keyX))
+			require.Equal(t, KeyValuePair{
+				Key:   keyX,
+				Value: value,
+			}, entry, string(keyX))
+
+			keyY := []byte(fmt.Sprintf("keyY %03d", i))
+			entry, ok, err = sameDB.Lookup(
+				[]byte(fmt.Sprintf("keyY %03d", i)),
+			)
+			require.NoError(t, err, string(keyY))
+			require.True(t, ok, string(keyY))
+			require.Equal(t, KeyValuePair{
+				Key:       keyY,
+				IsDeleted: true,
+			}, entry, string(keyY))
+		}
+	})
+}

--- a/db/lsm/cud.go
+++ b/db/lsm/cud.go
@@ -1,6 +1,8 @@
 package lsm
 
-import "github.com/navijation/njsimple/storage/keyvaluepair"
+import (
+	"github.com/navijation/njsimple/storage/keyvaluepair"
+)
 
 func (me *LSMDB) Upsert(key, value []byte) error {
 	ctx := &dbCtx{}
@@ -8,7 +10,7 @@ func (me *LSMDB) Upsert(key, value []byte) error {
 	ctx.Lock(&me.lock)
 	defer ctx.Unlock(&me.lock)
 
-	if err := me.checkStateErrorSafe(ctx); err != nil {
+	if err := me.checkStateError(ctx); err != nil {
 		return err
 	}
 

--- a/db/lsm/db_context.go
+++ b/db/lsm/db_context.go
@@ -46,3 +46,19 @@ func (me *dbCtx) RUnlock(lock *sync.RWMutex) {
 	}
 	me.ReadLockCounter--
 }
+
+func (me *dbCtx) LiftLock(lock *sync.RWMutex) {
+	if me.WriteLockCounter > 0 {
+		lock.Unlock()
+	} else {
+		lock.RUnlock()
+	}
+}
+
+func (me *dbCtx) ReinstateLock(lock *sync.RWMutex) {
+	if me.WriteLockCounter > 0 {
+		lock.Lock()
+	} else {
+		lock.RLock()
+	}
+}

--- a/db/lsm/journal_entry_test.go
+++ b/db/lsm/journal_entry_test.go
@@ -13,7 +13,6 @@ func TestCUDKeyValueEntry_Serialization(t *testing.T) {
 	t.Parallel()
 
 	t.Run("not deleted", func(t *testing.T) {
-
 		storedKVP := (&keyvaluepair.KeyValuePair{
 			Key:   []byte("key1"),
 			Value: []byte("value1"),
@@ -35,7 +34,6 @@ func TestCUDKeyValueEntry_Serialization(t *testing.T) {
 	})
 
 	t.Run("deleted", func(t *testing.T) {
-
 		storedKVP := (&KeyValuePair{
 			Key: []byte("key1"),
 		}).ToStoredKeyValuePair()

--- a/db/lsm/lsm.go
+++ b/db/lsm/lsm.go
@@ -223,8 +223,8 @@ func (me *LSMDB) Lookup(key []byte) (out keyvaluepair.KeyValuePair, exists bool,
 		if exists {
 			return keyvaluepair.KeyValuePair{
 				Key:       key,
-				Value:     entry.Key,
-				IsDeleted: false,
+				Value:     entry.Value,
+				IsDeleted: entry.IsDeleted,
 			}, true, nil
 		}
 	}

--- a/db/lsm/lsm_test.go
+++ b/db/lsm/lsm_test.go
@@ -82,6 +82,14 @@ func TestLSMDB_StartClose(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	assert.False(t, db.isRunning.Load())
+
 	require.NoError(t, db.Start())
+
+	assert.True(t, db.isRunning.Load())
+
 	require.NoError(t, db.Close())
+
+	assert.Empty(t, db.done)
+	assert.NoError(t, db.stateErr)
 }

--- a/db/lsm/util.go
+++ b/db/lsm/util.go
@@ -21,7 +21,7 @@ func (me *LSMDB) appendEntry(ctx *dbCtx, entry io.WriterTo) error {
 	return nil
 }
 
-func (me *LSMDB) checkStateErrorSafe(ctx *dbCtx) error {
+func (me *LSMDB) checkStateError(ctx *dbCtx) error {
 	if !me.isRunning.Load() {
 		return fmt.Errorf("database is not running")
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.2
 
 require (
 	github.com/google/uuid v1.6.0
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v3 v3.0.0-alpha9
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/storage/journal/journal.go
+++ b/storage/journal/journal.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"log"
 	"os"
 
 	"github.com/navijation/njsimple/util"
@@ -118,6 +119,7 @@ func (me *JournalFile) AppendEntry(content []byte) (out JournalEntry, err error)
 
 	defer func() {
 		if err != nil {
+			log.Printf("Failed to write entry: %s\n", err.Error())
 			// TODO: the hash won't be valid if appending an entry fails; need to somehow preserve old
 			// hash value; Go's library doesn't make it easy, so just going to recompute entire journal
 			// checksum for now whenever something fails
@@ -133,6 +135,7 @@ func (me *JournalFile) AppendEntry(content []byte) (out JournalEntry, err error)
 	internalEntry.ReadSignature(me.hash)
 
 	endOfFile := me.fileWrapperAt(me.size)
+
 	if _, err := internalEntry.WriteTo(&endOfFile); err != nil {
 		return out, err
 	}
@@ -165,6 +168,14 @@ func (me *JournalFile) Rename(newPath string) error {
 
 func (me *JournalFile) Path() string {
 	return me.path
+}
+
+func (me *JournalFile) Size() uint64 {
+	return me.size
+}
+
+func (me *JournalFile) NumEntries() uint64 {
+	return me.numberOfEntries
 }
 
 func (me *JournalFile) fileWrapperAt(offset uint64) util.FileWrapper {

--- a/storage/journal/journal_test.go
+++ b/storage/journal/journal_test.go
@@ -29,8 +29,8 @@ func TestOpen_NoEntries(t *testing.T) {
 
 	assert.Equal(t, uint64(5), file.header.start)
 	assert.NotZero(t, file.header.id)
-	assert.Equal(t, uint64(0), file.numberOfEntries)
-	assert.Equal(t, uint64(24), file.size)
+	assert.Equal(t, uint64(0), file.NumEntries())
+	assert.Equal(t, uint64(24), file.Size())
 	assert.False(t, file.isBad)
 	assert.NotNil(t, file.hash)
 	assert.NotEqual(t, sha256.New().Sum(nil), file.hash.Sum(nil))
@@ -51,7 +51,7 @@ func TestOpen_NoEntries(t *testing.T) {
 
 	assert.Equal(t, file.header, sameFile.header)
 	assert.Equal(t, file.numberOfEntries, sameFile.numberOfEntries)
-	assert.Equal(t, file.size, sameFile.size)
+	assert.Equal(t, file.Size(), sameFile.Size())
 	assert.Equal(t, file.isBad, sameFile.isBad)
 	assert.Equal(t, file.hash.Sum(nil), sameFile.hash.Sum(nil))
 }
@@ -82,7 +82,7 @@ func TestJournal_AppendAndIterate(t *testing.T) {
 		assert.Equal(t, uint64(5), file.header.start)
 		assert.NotZero(t, file.header.id)
 		assert.Equal(t, uint64(1), file.numberOfEntries)
-		assert.Equal(t, uint64(76), file.size)
+		assert.Equal(t, uint64(76), file.Size())
 		assert.False(t, file.isBad)
 		assert.NotNil(t, file.hash)
 	})
@@ -100,7 +100,7 @@ func TestJournal_AppendAndIterate(t *testing.T) {
 		assert.Equal(t, uint64(5), file.header.start)
 		assert.NotZero(t, file.header.id)
 		assert.Equal(t, uint64(2), file.numberOfEntries)
-		assert.Equal(t, uint64(130), file.size)
+		assert.Equal(t, uint64(130), file.Size())
 		assert.False(t, file.isBad)
 		assert.NotNil(t, file.hash)
 	})
@@ -111,8 +111,8 @@ func TestJournal_AppendAndIterate(t *testing.T) {
 	t.Run("re-open file", func(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, file.header, sameFile.header)
-		assert.Equal(t, file.numberOfEntries, sameFile.numberOfEntries)
-		assert.Equal(t, file.size, sameFile.size)
+		assert.Equal(t, file.NumEntries(), sameFile.NumEntries())
+		assert.Equal(t, file.Size(), sameFile.Size())
 		assert.Equal(t, file.isBad, sameFile.isBad)
 		assert.Equal(t, file.hash.Sum(nil), sameFile.hash.Sum(nil))
 	})
@@ -131,7 +131,7 @@ func TestJournal_AppendAndIterate(t *testing.T) {
 		// file should not be mutated by cursor
 		assert.Equal(t, file.header, sameFile.header)
 		assert.Equal(t, file.numberOfEntries, sameFile.numberOfEntries)
-		assert.Equal(t, file.size, sameFile.size)
+		assert.Equal(t, file.Size(), sameFile.Size())
 		assert.Equal(t, file.isBad, sameFile.isBad)
 		assert.Equal(t, file.hash.Sum(nil), sameFile.hash.Sum(nil))
 
@@ -172,7 +172,7 @@ func TestJournal_CorruptionHandling(t *testing.T) {
 		rawFile, err := os.OpenFile(file.path, os.O_RDWR, 0)
 		require.NoError(t, err)
 
-		_, err = rawFile.WriteAt([]byte("deadbeef"), int64(file.size))
+		_, err = rawFile.WriteAt([]byte("deadbeef"), int64(file.Size()))
 		require.NoError(t, err)
 
 		assert.NoError(t, rawFile.Close())
@@ -184,7 +184,7 @@ func TestJournal_CorruptionHandling(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, file.header, sameFile.header)
 		assert.Equal(t, file.numberOfEntries, sameFile.numberOfEntries)
-		assert.Equal(t, file.size, sameFile.size)
+		assert.Equal(t, file.Size(), sameFile.Size())
 		assert.Equal(t, file.isBad, sameFile.isBad)
 		assert.Equal(t, file.hash.Sum(nil), sameFile.hash.Sum(nil))
 	})
@@ -193,7 +193,7 @@ func TestJournal_CorruptionHandling(t *testing.T) {
 		rawFile, err := os.OpenFile(file.path, os.O_RDWR, 0)
 		require.NoError(t, err)
 
-		_, err = rawFile.WriteAt([]byte("deadbeef"), int64(file.size-8))
+		_, err = rawFile.WriteAt([]byte("deadbeef"), int64(file.Size()-8))
 		require.NoError(t, err)
 
 		assert.NoError(t, rawFile.Close())
@@ -205,7 +205,7 @@ func TestJournal_CorruptionHandling(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, file.header, corruptedFile.header)
 		assert.Equal(t, file.numberOfEntries-1, corruptedFile.numberOfEntries)
-		assert.Equal(t, file.size-entry2.SizeOf(), corruptedFile.size)
+		assert.Equal(t, file.Size()-entry2.SizeOf(), corruptedFile.Size())
 		assert.False(t, corruptedFile.isBad)
 		assert.Equal(t, hash1, corruptedFile.hash.Sum(nil))
 	})

--- a/storage/sstable/entry.go
+++ b/storage/sstable/entry.go
@@ -127,11 +127,13 @@ func (me *internalSSTableEntry) ReadFrom(reader io.Reader) (n int64, err error) 
 	}
 	me.ValueSize = valueSize
 
-	me.Value = make([]byte, valueSize)
-	dn, err = io.ReadAtLeast(reader, me.Value, int(valueSize))
-	n += int64(dn)
-	if err != nil {
-		return n, err
+	if me.ValueSize > 0 {
+		me.Value = make([]byte, valueSize)
+		dn, err = io.ReadAtLeast(reader, me.Value, int(valueSize))
+		n += int64(dn)
+		if err != nil {
+			return n, err
+		}
 	}
 
 	return n, nil

--- a/storage/sstable/sstable.go
+++ b/storage/sstable/sstable.go
@@ -254,6 +254,10 @@ func (me *SSTable) Header() Header {
 	return me.header
 }
 
+func (me *SSTable) NumEntries() uint64 {
+	return me.header.NumEntries
+}
+
 func (me *SSTable) Index() SparseMemIndex {
 	return SparseMemIndex{
 		ChunkSize: me.index.ChunkSize,

--- a/util/files.go
+++ b/util/files.go
@@ -9,7 +9,7 @@ func FileExists(path string) (exists bool, _ error) {
 	if _, err := os.Stat(path); err == nil {
 		return true, nil
 	} else if errors.Is(err, os.ErrNotExist) {
-		return false, err
+		return false, nil
 	} else {
 		return false, err
 	}


### PR DESCRIPTION
Implement and test async SSTable creation. This implementation tries to keep the database available for reads and
writes while an SSTable file is being written to disk. Only the synchronous component blocks the database from
performing reads and writes.

## Sync SSTable Creation

**Sync SSTable creation** involves the following steps, all behind a write lock, blocking other operations

1. Append a writeahead log entry that includes the next SSTable number and next writeahead log number
2. Create a new primary writeahead log to receive incoming write operations during async SSTable creation
  a. Keep old log as secondary until SSTable creation succeeds to ensure durability
3. Create a new primary in-memory index to service incoming write operations during async SSTable creation
  a. Keep old in-memory index as secondary until SSTable creation succeeds to service reads to that table's contents
4. Trigger async SSTable creation

## Async SSTable Creation

**Async SSTable creation** involves the following steps, none behind a write lock, except for steps 5-8

1. Read the SSTable creation entry, which contains the SSTable number and writeahead log number, as well as a reference
  to the secondary in-memory index that needs to be written
2. Create a new SSTable file in a temporary location: in `./tmp` directory, random file name
3. Append all entries from the secondary in-memory index into this file
4. Rename the temporary file to its canonical name: `./sstable_file_${ssTableNumber}.sst`
5. Insert SSTable file into in-memory list of SSTable files
6. Remove secondary in-memory index from list
7. Delete secondary writeahead log file from disk
8. Remove writeahead log fromin-memory list of writeahead log files